### PR TITLE
Add MiniMax as a built-in LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Throw files against LLMs.
 
-llmaid is a command-line tool designed to automate the process of AI supported file changes using large language models. It reads source code files, sends them to Ollama, LM Studio, or any OpenAI-compatible API, and writes back the models answers. The tool is highly configurable and supports every kind of text-based and most image input file formats.
+llmaid is a command-line tool designed to automate the process of AI supported file changes using large language models. It reads source code files, sends them to Ollama, LM Studio, MiniMax, or any OpenAI-compatible API, and writes back the models answers. The tool is highly configurable and supports every kind of text-based and most image input file formats.
 
 ---
 
@@ -175,7 +175,7 @@ llmaid --profile ./profiles/code-documenter.yaml --verbose
 ```
 
 Available arguments:
-- `--provider` – ollama, openai, lmstudio, openai-compatible
+- `--provider` – ollama, openai, lmstudio, openai-compatible, minimax
 - `--uri` – API endpoint URL
 - `--apiKey` – API key (if required)
 - `--model` – Model identifier
@@ -205,8 +205,25 @@ Available arguments:
 | `ollama` | `http://localhost:11434` | No |
 | `lmstudio` | `http://localhost:1234/v1` | No (use empty string or any placeholder) |
 | `openai` | `https://api.openai.com/v1` | Yes |
+| `minimax` | `https://api.minimax.io/v1` | Yes |
 | `openai-compatible` | Your server's URL | Depends on server |
 
+
+#### MiniMax
+
+[MiniMax](https://www.minimax.io) provides high-performance models with a 204,800 token context window. Available models:
+
+| Model | Description |
+|-------|-------------|
+| `MiniMax-M2.5` | Default model – peak performance, ultimate value |
+| `MiniMax-M2.5-highspeed` | Same performance, faster and more agile |
+
+```bash
+llmaid --provider minimax --apiKey YOUR_MINIMAX_API_KEY --model MiniMax-M2.5 --profile ./profiles/code-documenter.yaml --targetPath ./src
+```
+
+> [!NOTE]
+> MiniMax requires a temperature value between 0 and 1 (exclusive of 0). If you use `--temperature`, make sure to set it to a value greater than 0 (e.g. `0.01` instead of `0`).
 
 ### System Prompt Placeholders
 

--- a/llmaid/ChatClientFactory.cs
+++ b/llmaid/ChatClientFactory.cs
@@ -5,7 +5,7 @@ using OllamaSharp;
 namespace llmaid;
 
 /// <summary>
-/// Creates an <see cref="IChatClient"/> for the configured provider (Ollama, LM Studio, OpenAI).
+/// Creates an <see cref="IChatClient"/> for the configured provider (Ollama, LM Studio, OpenAI, MiniMax).
 /// </summary>
 internal static class ChatClientFactory
 {
@@ -17,6 +17,9 @@ internal static class ChatClientFactory
 
 		if (provider.Equals("ollama", StringComparison.OrdinalIgnoreCase))
 			return CreateOllamaClient(settings);
+
+		if (provider.Equals("minimax", StringComparison.OrdinalIgnoreCase))
+			return CreateMiniMaxClient(settings);
 
 		if (provider.Equals("lmstudio", StringComparison.OrdinalIgnoreCase) || provider.Equals("openai-compatible", StringComparison.OrdinalIgnoreCase))
 			return CreateOpenAICompatibleClient(settings);
@@ -41,6 +44,21 @@ internal static class ChatClientFactory
 		var options = new OpenAI.OpenAIClientOptions { Endpoint = settings.Uri, NetworkTimeout = _networkTimeout };
 		return new OpenAI.OpenAIClient(new ApiKeyCredential(apiKey), options)
 			.GetChatClient(settings.Model ?? string.Empty)
+			.AsIChatClient();
+	}
+
+	/// <summary>
+	/// Creates a client for MiniMax using its OpenAI-compatible API.
+	/// Default endpoint: https://api.minimax.io/v1.
+	/// API key is required and can be set via the MINIMAX_API_KEY environment variable.
+	/// </summary>
+	private static IChatClient CreateMiniMaxClient(Settings settings)
+	{
+		var apiKey = settings.ApiKey ?? string.Empty;
+		var endpoint = settings.Uri ?? new Uri("https://api.minimax.io/v1");
+		var options = new OpenAI.OpenAIClientOptions { Endpoint = endpoint, NetworkTimeout = _networkTimeout };
+		return new OpenAI.OpenAIClient(new ApiKeyCredential(apiKey), options)
+			.GetChatClient(settings.Model ?? "MiniMax-M2.5")
 			.AsIChatClient();
 	}
 

--- a/llmaid/Settings.cs
+++ b/llmaid/Settings.cs
@@ -16,9 +16,10 @@ public class Settings
 	public bool IsEmpty => string.IsNullOrWhiteSpace(Provider);
 
 	/// <summary>
-	/// Gets or sets the provider name, which must be 'ollama', 'openai', 'lmstudio', or 'openai-compatible'.
+	/// Gets or sets the provider name, which must be 'ollama', 'openai', 'lmstudio', 'openai-compatible', or 'minimax'.
 	/// Use 'lmstudio' for LM Studio's local API (default: http://localhost:1234/v1).
 	/// Use 'openai-compatible' for any other OpenAI-compatible API endpoints.
+	/// Use 'minimax' for MiniMax's API (default: https://api.minimax.io/v1).
 	/// </summary>
 	[JsonPropertyName("provider")]
 	public string? Provider { get; set; }
@@ -195,9 +196,10 @@ public class Settings
 		var knownProvider = "ollama".Equals(Provider, StringComparison.OrdinalIgnoreCase)
 			|| "openai".Equals(Provider, StringComparison.OrdinalIgnoreCase)
 			|| "lmstudio".Equals(Provider, StringComparison.OrdinalIgnoreCase)
-			|| "openai-compatible".Equals(Provider, StringComparison.OrdinalIgnoreCase);
+			|| "openai-compatible".Equals(Provider, StringComparison.OrdinalIgnoreCase)
+			|| "minimax".Equals(Provider, StringComparison.OrdinalIgnoreCase);
 		if (!knownProvider)
-			throw new ArgumentException("Provider has to be 'ollama', 'openai', 'lmstudio', or 'openai-compatible'.");
+			throw new ArgumentException("Provider has to be 'ollama', 'openai', 'lmstudio', 'openai-compatible', or 'minimax'.");
 
 		if (string.IsNullOrEmpty(TargetPath))
 			throw new ArgumentException("Target path has to be defined.");


### PR DESCRIPTION
## Summary

- Add first-class `minimax` provider support to llmaid, enabling users to use [MiniMax](https://www.minimax.io) models (MiniMax-M2.5, MiniMax-M2.5-highspeed) with a simple `--provider minimax` flag
- MiniMax offers a 204,800 token context window at competitive pricing ($0.3/M input, $1.2/M output for M2.5)
- Default endpoint set to `https://api.minimax.io/v1` with `MiniMax-M2.5` as the default model

## Changes

- **ChatClientFactory.cs**: Added `CreateMiniMaxClient()` method with sensible defaults (endpoint, model) following the existing provider pattern
- **Settings.cs**: Registered `minimax` as a known provider in validation logic and updated doc comments
- **README.md**: Added MiniMax to the supported providers table, usage example, and documented the temperature constraint (must be > 0)

## Test plan

- [x] `dotnet build` succeeds with zero warnings/errors
- [x] All 50 existing unit tests pass
- [x] Integration test: sent a real request to MiniMax API with `--provider minimax` and received a valid response

🤖 Generated with [Claude Code](https://claude.com/claude-code)